### PR TITLE
github profile link on index opens in new tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <body>
       <!-- front links -->
       <div id="front-link-section">
-        <a href="https://github.com/avisochek" class="front-link">
+        <a href="https://github.com/avisochek" class="front-link" target="_blank">
           <h3>Github</h3>
           <div id="github-link" class="front-icon"></div>
         </a>


### PR DESCRIPTION
I changed it so clicking the github link on the website opens the github profile in a new tab instead of the same window.
